### PR TITLE
Bug: attempts to load data into a table that throws errors on table creation

### DIFF
--- a/src/actors/sqlite.rs
+++ b/src/actors/sqlite.rs
@@ -60,28 +60,33 @@ pub struct SqliteCreateTable {
 }
 
 impl Message for SqliteCreateTable {
-    type Result = String;
+    type Result = Result<String, String>;
 }
 
 impl Handler<SqliteCreateTable> for SQLGen {
-    type Result = String;
+    type Result = Result<String, String>;
 
     fn handle(&mut self, msg: SqliteCreateTable, _: &mut Context<Self>) -> Self::Result {
-        let table_sql = match SQLGen::generate_create_table(&msg.table_name, &msg.columns) {
+        match SQLGen::generate_create_table(&msg.table_name, &msg.columns) {
             Ok(create_table_sql) => {
                 match msg.db_conn.create_table(create_table_sql.clone()) {
-                    Ok(_) => println!("Created table {}", &msg.table_name),
-                    Err(e) => eprintln!("Error creating table: {}", e)
+                    Ok(_) => {
+                        println!("Created table {}", &msg.table_name);
+                        return Ok("".to_string())
+                    },
+                    Err(e) => {
+                        return Err(format!("ERROR creating table: {}", e))
+                    }
                 }
-                create_table_sql
             },
             Err(e) => {
                 eprintln!("[generate_create_table] Error: {}", e);
-                String::from("")
+                return Err(String::from(""))
             }
         };
         
-        table_sql
+        // println!("results: {:?}", results);
+        // results
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,20 +204,29 @@ fn sqlite_load_table(cfg: Config, table_name: &str, columns: Vec<ColumnDef>, con
         db_conn: db_conn,
         table_name: table_name.to_string(),
     });
+
     
     Arbiter::spawn(res.then( move |res| {
         match res {
             // now that the table is created I can insert the data
-            Ok(_) => {
-                let writer_dbconn = SqliteDB::new(&db_uri).unwrap();
-                let stmt = SQLGen::generate_insert_stmt(&tname, &columns.clone()).unwrap();
-                
-                match writer_dbconn.insert_rows(stmt, &columns, contents) {
-                    Ok(num_inserted) => println!("{} records insert into {}", num_inserted, tname),
-                    Err(e) => eprintln!("ERROR: {} inserting record into {}", e, tname)
+            Ok(msg) => {
+                match msg {
+                    Ok(_) => {
+                        let writer_dbconn = SqliteDB::new(&db_uri).unwrap();
+                        let stmt = SQLGen::generate_insert_stmt(&tname, &columns.clone()).unwrap();
+                        
+                        match writer_dbconn.insert_rows(stmt, &columns, contents) {
+                            Ok(num_inserted) => println!("{} records insert into {}", num_inserted, tname),
+                            Err(e) => eprintln!("ERROR: {} inserting record into {}", e, tname)
+                        }
+                    },
+                    Err(e) => {
+                        eprintln!("ERROR: {}", e)
+                    }
                 }
-            },
-            _ => println!("Something wrong"),
+            }
+            ,
+            _ => unreachable!(),
         }
         
         System::current().stop();


### PR DESCRIPTION
reworked how the table already exists error is propigated back to the caller so that I don't blindly reload the data in a table that already exists. At some point I will add a flag to say its ok but for now, its not.  Fixed at triangle rustaceans meetup