### PR TITLE
Added a validator function to validate the toml path provided

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "csv2api"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "actix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "barrel 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "csv2api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "actix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "barrel 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csv2api"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Rob Rowe <robrowe04@gmail.com>"]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "csv2api"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Rob Rowe <robrowe04@gmail.com>"]
 
 [workspace]
+members = ["csv_converter"]
 
-[dependencies]
+[dependencies] 
 csv_converter = { path = "csv_converter"}
 actix = "0.7.0"
 barrel = "0.2.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
     let default_toml_file = "csv2api.toml";
 
     let matches = clap::App::new("csv2api")
-        .version("0.0.1")
+        .version(clap::crate_version!())
         .about("Parses and stores Wikipedia conspiracy theories data")
         .author("Rob Rowe.")
         .arg(clap::Arg::with_name("toml")


### PR DESCRIPTION
* Added a validator to the toml parameter
* re-used the validator to ensure there is a default toml file (csv2api.toml) exists prior to attempting to open it
* switched over to use the clap::crate_version!() to set the binary's version number
